### PR TITLE
Fixed issues with flashing.

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -1,5 +1,5 @@
 #!/sbin/sh
-# Droidian GSI Backend
+# Droidian rootfs Backend
 # Based on ubports GSI script by erfanoabdi @ xda-developers
 
 OUTFD=/proc/self/fd/$2;
@@ -68,7 +68,7 @@ abort() { ui_print "$*"; umount /vendor; umount /data; exit 1; }
 show_progress 1.34 4;
 ui_print " ";
 ui_print "***";
-ui_print "Droidian GSI installer";
+ui_print "Droidian rootfs installer";
 ui_print "https://droidian.org";
 ui_print "***";
 ui_print " ";
@@ -90,7 +90,7 @@ mkdir -p /data/droidian;
 cd /data/droidian;
 
 # unzip busybox and rootfs
-ui_print "Installing GSI...";
+ui_print "Installing Droidian...";
 unzip -o "$ZIP";
 
 if [ $? != 0 -o -z "$(ls /data/droidian/tools)" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -56,10 +56,10 @@ get_partitions() {
 if [ -e "$(ls /r/boot/boot.img*)" ]; then
     ui_print "Kernel found, flashing"
     get_partitions
-    partition=$(find /dev/block/platform -name "$target_boot_partition" | head -n 1)
+    partition=$(find /dev/block/by-name -name "$target_boot_partition" | head -n 1)
     if [ -n "${partition}" ]; then
 		ui_print "Found boot partition for current slot ${partition}"
-		dd if=/r/boot/boot.img* of="${partition}" || error "Unable to flash kernel"
+        dd if="$(find /r/boot -name 'boot.img*')" of="${partition}" || error "Unable to flash kernel"
 		ui_print "Kernel flashed"
 	fi
 fi
@@ -68,10 +68,10 @@ fi
 if [ -e "$(ls /r/boot/dtbo.img*)" ]; then
     ui_print "DTBO found, flashing"
     get_partitions
-    partition=$(find /dev/block/platform -name "$target_dtbo_partition" | head -n 1)
+    partition=$(find /dev/block/by-name -name "$target_dtbo_partition" | head -n 1)
     if [ -n "${partition}" ]; then
         ui_print "Found DTBO partition for current slot ${partition}"
-        dd if=/r/boot/dtbo.img* of="${partition}" || error "Unable to flash DTBO"
+        dd if="$(find /r/boot -name 'dtbo.img*')" of="${partition}" || error "Unable to flash DTBO"
         ui_print "DTBO flashed"
     fi
 fi
@@ -79,10 +79,10 @@ fi
 # If we should flash the vbmeta, do it
 if [ -e "$(ls /r/boot/vbmeta.img*)" ]; then
     ui_print "VBMETA found, flashing"
-    partition=$(find /dev/block/platform -name "$target_vbmeta_partition" | head -n 1)
+    partition=$(find /dev/block/by-name -name "$target_vbmeta_partition" | head -n 1)
     if [ -n "${partition}" ]; then
         ui_print "Found VBMETA partition ${partition}"
-        dd if=/r/boot/vbmeta.img* of="${partition}" || error "Unable to flash VBMETA"
+        dd if="$(find /r/boot -name 'vbmeta.img*')" of="${partition}" || error "Unable to flash VBMETA"
         ui_print "VBMETA flashed"
     fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-# Droidian GSI installer Script
+# Droidian rootfs installer script
 # https://droidian.org
 
 OUTFD=/proc/self/fd/$1;
@@ -7,7 +7,7 @@ VENDOR_DEVICE_PROP=`grep ro.product.vendor.device /vendor/build.prop | cut -d "=
 # ui_print <text>
 ui_print() { echo -e "ui_print $1\nui_print" > $OUTFD; }
 
-## GSI install
+## rootfs install
 mv /data/droidian/data/* /data/;
 
 # resize rootfs


### PR DESCRIPTION
Flashing of boot.img for example wouldn't work if the devices partitions weren't listed under /dev/block/platform.
/dev/block/platform seems to have different contents from device to device but /dev/block/by-name seems to always have a list of the partition names so switched to use that and fixed an issue with dd command syntax